### PR TITLE
[BUGFIX] Replace url-parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,14 @@ if (!program.args[0]) {
   process.exit(-1)
 }
 
-url = URL.parse(program.args[0])
+try {
+  url = new URL.URL(program.args[0])
+} catch (err) {
+  if (err instanceof TypeError) {
+    console.log('Invalid URL. Protocol is not given or URL is malformed.')
+    process.exit(-1)
+  }
+}
 url.method = method
 url.observe = program.observe
 url.confirmable = !program.nonConfirmable

--- a/test.js
+++ b/test.js
@@ -33,8 +33,15 @@ describe('coap', function () {
     return child
   }
 
-  it('should error with a wrong URL', function (done) {
+  it('should error with a invalid URL', function (done) {
     call('abcde').stdout.pipe(concat(function (data) {
+      expect(data.toString()).to.eql('Invalid URL. Protocol is not given or URL is malformed.\n')
+      done()
+    }))
+  })
+
+  it('should error with a wrong URL', function (done) {
+    call('http://abcde').stdout.pipe(concat(function (data) {
       expect(data.toString()).to.eql('Wrong URL. Protocol is not coap or no hostname found.\n')
       done()
     }))


### PR DESCRIPTION
Increasing dependency "standard" from ^12.0.1 to 13.0.0
breaks tests, because URL.parse() is deprecated.
Use URL.URL() constructor instead, catch Exception and
adapt tests.