### PR TITLE
fix: repeatable options

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,11 +87,20 @@ if (program.opts().block2) {
 }
 
 if (typeof program.opts().coapOption !== 'undefined' && program.opts().coapOption.length > 0) {
+  const options = {}
+  // calling req.setOption() multiple times for the same key will overwrite previous values,
+  // therefore group options by name/key and add them all at once
   program.opts().coapOption.forEach(function (singleOption) {
     const i = singleOption.indexOf(coapOptionSeperator)
-    const kvPair = [singleOption.slice(0, i), singleOption.slice(i + 1)]
-    const optionValueBuffer = kvPair[1].startsWith('0x') ? Buffer.from(kvPair[1].substring(2), 'hex') : Buffer.from(kvPair[1])
-    req.setOption(kvPair[0], optionValueBuffer)
+    const key = singleOption.slice(0, i)
+    const value = singleOption.slice(i + 1)
+    const valueBuffer = value.startsWith('0x') ? Buffer.from(value.substring(2), 'hex') : Buffer.from(value)
+    if (!Object.prototype.hasOwnProperty.call(options, key)) options[key] = []
+    options[key].push(valueBuffer)
+  })
+  console.log('adding options:', options)
+  Object.entries(options).forEach(([key, values]) => {
+    req.setOption(key, values)
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -98,7 +98,6 @@ if (typeof program.opts().coapOption !== 'undefined' && program.opts().coapOptio
     if (!Object.prototype.hasOwnProperty.call(options, key)) options[key] = []
     options[key].push(valueBuffer)
   })
-  console.log('adding options:', options)
   Object.entries(options).forEach(([key, values]) => {
     req.setOption(key, values)
   })

--- a/test.js
+++ b/test.js
@@ -340,4 +340,24 @@ describe('coap', function () {
       }
     })
   })
+
+  it('should support multiple coap options with the same option number in any order', function (done) {
+    call('get', '-O 15,sharedKeys=foo,bar,baz', '-O 2050,narf', '-O 15,clientKeys=coap,is,life', 'coap://localhost')
+
+    server.once('request', function (req, res) {
+      res.end('')
+      try {
+        expect(req._packet.options.length).to.eql(3)
+        expect(req._packet.options[0].name).to.eql('Uri-Query')
+        expect(req._packet.options[0].value.toString()).to.eql('sharedKeys=foo,bar,baz')
+        expect(req._packet.options[1].name).to.eql('Uri-Query')
+        expect(req._packet.options[1].value.toString()).to.eql('clientKeys=coap,is,life')
+        expect(req._packet.options[2].name).to.eql('2050')
+        expect(req._packet.options[2].value.toString()).to.eql('narf')
+        done()
+      } catch (err) {
+        done(err)
+      }
+    })
+  })
 })

--- a/test.js
+++ b/test.js
@@ -7,6 +7,15 @@ const concat = require('concat-stream')
 const spawn = require('child_process').spawn
 const replace = require('event-stream').replace
 
+// verify that the coap-options are exactly as expected
+function expectOptions (req, expectedOptions) {
+  expect(req._packet.options.length).to.eql(expectedOptions.length)
+  expectedOptions.forEach(([key, value], i) => {
+    expect(req._packet.options[i].name).to.eql(key)
+    expect(req._packet.options[i].value.toString()).to.eql(value)
+  })
+}
+
 describe('coap', function () {
   let server
 
@@ -245,9 +254,9 @@ describe('coap', function () {
     server.once('request', function (req, res) {
       res.end('')
       try {
-        expect(req._packet.options.length).to.eql(1)
-        expect(req._packet.options[0].name).to.eql('2048')
-        expect(req._packet.options[0].value.toString()).to.eql('HelloWorld')
+        expectOptions(req, [
+          ['2048', 'HelloWorld']
+        ])
         done()
       } catch (err) {
         done(err)
@@ -261,11 +270,10 @@ describe('coap', function () {
     server.once('request', function (req, res) {
       res.end('')
       try {
-        expect(req._packet.options.length).to.eql(2)
-        expect(req._packet.options[0].name).to.eql('2048')
-        expect(req._packet.options[0].value.toString()).to.eql('HelloWorld')
-        expect(req._packet.options[1].name).to.eql('2050')
-        expect(req._packet.options[1].value.toString()).to.eql('FooBarBaz')
+        expectOptions(req, [
+          ['2048', 'HelloWorld'],
+          ['2050', 'FooBarBaz']
+        ])
         done()
       } catch (err) {
         done(err)
@@ -279,9 +287,9 @@ describe('coap', function () {
     server.once('request', function (req, res) {
       res.end('')
       try {
-        expect(req._packet.options.length).to.eql(1)
-        expect(req._packet.options[0].name).to.eql('2048')
-        expect(req._packet.options[0].value.toString()).to.eql('a')
+        expectOptions(req, [
+          ['2048', 'a']
+        ])
         done()
       } catch (err) {
         done(err)
@@ -295,11 +303,10 @@ describe('coap', function () {
     server.once('request', function (req, res) {
       res.end('')
       try {
-        expect(req._packet.options.length).to.eql(2)
-        expect(req._packet.options[0].name).to.eql('2048')
-        expect(req._packet.options[0].value.toString()).to.eql('a')
-        expect(req._packet.options[1].name).to.eql('2050')
-        expect(req._packet.options[1].value.toString()).to.eql('b')
+        expectOptions(req, [
+          ['2048', 'a'],
+          ['2050', 'b']
+        ])
         done()
       } catch (err) {
         done(err)
@@ -313,11 +320,10 @@ describe('coap', function () {
     server.once('request', function (req, res) {
       res.end('')
       try {
-        expect(req._packet.options.length).to.eql(2)
-        expect(req._packet.options[0].name).to.eql('2048')
-        expect(req._packet.options[0].value.toString()).to.eql('a')
-        expect(req._packet.options[1].name).to.eql('2050')
-        expect(req._packet.options[1].value.toString()).to.eql('FooBarBaz')
+        expectOptions(req, [
+          ['2048', 'a'],
+          ['2050', 'FooBarBaz']
+        ])
         done()
       } catch (err) {
         done(err)
@@ -331,9 +337,9 @@ describe('coap', function () {
     server.once('request', function (req, res) {
       res.end('')
       try {
-        expect(req._packet.options.length).to.eql(1)
-        expect(req._packet.options[0].name).to.eql('Uri-Query')
-        expect(req._packet.options[0].value.toString()).to.eql('sharedKeys=foo,bar,baz')
+        expectOptions(req, [
+          ['Uri-Query', 'sharedKeys=foo,bar,baz']
+        ])
         done()
       } catch (err) {
         done(err)
@@ -347,13 +353,11 @@ describe('coap', function () {
     server.once('request', function (req, res) {
       res.end('')
       try {
-        expect(req._packet.options.length).to.eql(3)
-        expect(req._packet.options[0].name).to.eql('Uri-Query')
-        expect(req._packet.options[0].value.toString()).to.eql('sharedKeys=foo,bar,baz')
-        expect(req._packet.options[1].name).to.eql('Uri-Query')
-        expect(req._packet.options[1].value.toString()).to.eql('clientKeys=coap,is,life')
-        expect(req._packet.options[2].name).to.eql('2050')
-        expect(req._packet.options[2].value.toString()).to.eql('narf')
+        expectOptions(req, [
+          ['Uri-Query', 'sharedKeys=foo,bar,baz'],
+          ['Uri-Query', 'clientKeys=coap,is,life'],
+          ['2050', 'narf']
+        ])
         done()
       } catch (err) {
         done(err)


### PR DESCRIPTION
This allows adding multiple options with the same option number. Currently, only the last value would be set, previous ones are overwritten.

I also refactored the tests a little to simplify verifying correct options have been set.

Example
`coap get coap://localhost/test -O 15,queryParam1 -O 15,queryParam2`

Before this patch this would result in a request with two options:
1. `Uri-Path: test`
2. `Uri-Query: queryParam2`

After this patch there will be two "Uri-Query" options with values `queryParam1` and `queryParam2`, respectively, in that order:
1. `Uri-Path: test`
2. `Uri-Query: queryParam1`
3. `Uri-Query: queryParam2`

**Checklist**

- [x] Tests have been created, run and adjusted as needed
