### PR TITLE
chore: update coap to version 1.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "coap-cli",
-  "version": "0.10.0",
   "lockfileVersion": 1,
+  "version": "0.11.0",
   "requires": true,
   "dependencies": {
     "@eslint/eslintrc": {
@@ -110,7 +110,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv": {
       "version": "6.12.6",
@@ -415,9 +416,9 @@
       }
     },
     "coap": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.8.tgz",
-      "integrity": "sha512-hG4KL7Js3435/zO1HlprkHqCyBTIsYkwgEA1lY5fsp8UX7VpkSe77JpWNWz4KUHXGeyo2GuLAe9+I+NxnhuOdA==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/coap/-/coap-1.0.11.tgz",
+      "integrity": "sha512-38BP98kiOzpv45aX1YmjR1OskPnHRQ3V/w43Ogp05sUGShhxVPBwmfjDRPHrpP8WnJbhwAdrj9WghaQ4ZxpHOQ==",
       "requires": {
         "@types/bl": "^5.0.2",
         "@types/lru-cache": "^5.1.1",
@@ -759,13 +760,15 @@
       "version": "17.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.0.0.tgz",
       "integrity": "sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-standard-jsx": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-11.0.0.tgz",
       "integrity": "sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.6",
@@ -966,7 +969,8 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.0.0.tgz",
       "integrity": "sha512-7GPezalm5Bfi/E22PnQxDWH2iW9GTvAlUNTztemeHb6c1BniSyoeTrM87JkC0wYdi6aQrZX9p2qEiAno8aTcbw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.29.4",
@@ -2358,6 +2362,21 @@
         "through": "~2.3.4"
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
     "string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -2405,21 +2424,6 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.19.5"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        }
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "standard": "^17.0.0"
   },
   "dependencies": {
-    "coap": "~1.0.0",
+    "coap": "^1.0.11",
     "commander": "~9.2.0",
     "minimist": ">=1.2.6",
     "through2": "~4.0.2",


### PR DESCRIPTION
This PR updates node-coap to a minimum version of 1.0.11, incorporating https://github.com/mcollina/node-coap/pull/346, which fixes #136. I hope the formats of the package.json and package-lock.json files are fine, otherwise let me know :)
